### PR TITLE
Add script to brute force top-25 Great League teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ This started as a passion project that went from “I wonder what this would loo
 
 See the [Installation](https://github.com/pvpoke/pvpoke/wiki/Installation) section of the PvPoke Wiki.
 
+## Top 25 Team Combinations (Great League)
+
+The `src/scripts/top25triplets.js` script exhaustively evaluates every team of three from the top 25 Great League meta. Each trio is tested against the meta across the 0-0, 1-1, and 2-2 shield scenarios to find the highest-scoring combination.
+
+Run the script locally with:
+
+```bash
+npm run triplets:top25
+```
+
+Processing all 2300 combinations may take significant time. For a quicker trial run, append `--limit=<number>` to evaluate only the first N combinations.
+
 ## Site Structure
 
 It was about 10 minutes into development when I realized this project would be great in Angular, but that was unfortunately 5 minutes past the point I was willing to backtrack. So allow me to show you the result.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pvpoke",
+  "version": "1.0.0",
+  "description": "Utilities for PvPoke simulations",
+  "type": "commonjs",
+  "scripts": {
+    "test": "echo \"No test suite provided\" && exit 0",
+    "triplets:top25": "node src/scripts/top25triplets.js"
+  }
+}
+

--- a/src/scripts/top25triplets.js
+++ b/src/scripts/top25triplets.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// Minimal GameMaster implementation loading gamemaster data
+const gmData = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/gamemaster.min.json')));
+const GameMaster = (function(){
+  let instance;
+  function create(){
+    return {
+      data: gmData,
+      moveMap: new Map(gmData.moves.map(m => [m.moveId, m])),
+      pokemonMap: new Map(gmData.pokemon.map(p => [p.speciesId, p])),
+      getPokemonById(id){
+        return JSON.parse(JSON.stringify(this.pokemonMap.get(id)));
+      },
+      getMoveById(id){
+        return JSON.parse(JSON.stringify(this.moveMap.get(id)));
+      },
+      getCupById(id){
+        return { name: id, include: [], exclude: [{ filterType: 'tag', values: ['mega'] }] };
+      }
+    };
+  }
+  return {
+    getInstance(){
+      if(!instance){ instance = create(); }
+      return instance;
+    }
+  };
+})();
+
+global.GameMaster = GameMaster;
+
+// Load battle engine scripts into this context
+function load(file){
+  vm.runInThisContext(fs.readFileSync(file, 'utf8'), { filename: file });
+}
+const root = path.join(__dirname, '..', 'js');
+load(path.join(root, 'battle', 'DamageCalculator.js'));
+load(path.join(root, 'battle', 'timeline', 'TimelineEvent.js'));
+load(path.join(root, 'battle', 'timeline', 'TimelineAction.js'));
+load(path.join(root, 'battle', 'actions', 'ActionLogic.js'));
+load(path.join(root, 'battle', 'Battle.js'));
+load(path.join(root, 'pokemon', 'Pokemon.js'));
+
+// Select first available moveset for a Pokemon
+function selectDefaultMoves(p){
+  p.selectMove('fast', p.fastMovePool[0].moveId);
+  p.selectMove('charged', p.chargedMovePool[0].moveId, 0);
+  if(p.chargedMovePool.length > 1){
+    p.selectMove('charged', p.chargedMovePool[1].moveId, 1);
+  } else {
+    p.selectMove('charged', 'none', 1);
+  }
+}
+
+// Run a single battle and return rating for the attacker
+function simulate(attackerId, defenderId, shieldsA, shieldsB){
+  const battle = new Battle();
+  battle.setCP(1500);
+  battle.setCup('all');
+
+  const attacker = new Pokemon(attackerId, 0, battle);
+  battle.setNewPokemon(attacker, 0, true);
+  selectDefaultMoves(attacker);
+  attacker.setShields(shieldsA);
+
+  const defender = new Pokemon(defenderId, 1, battle);
+  battle.setNewPokemon(defender, 1, true);
+  selectDefaultMoves(defender);
+  defender.setShields(shieldsB);
+
+  battle.simulate();
+  return battle.getBattleRatings()[0];
+}
+
+// Load ranking data and extract top 25 species
+const rankings = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/rankings/all/overall/rankings-1500.json')));
+const top25 = rankings.slice(0,25).map(p => p.speciesId);
+
+const shieldScenarios = [ [0,0], [1,1], [2,2] ];
+
+function* combinations(arr, k, start=0, prefix=[]){
+  if(k === 0){
+    yield prefix;
+    return;
+  }
+  for(let i=start; i<=arr.length - k; i++){
+    yield* combinations(arr, k-1, i+1, prefix.concat(arr[i]));
+  }
+}
+
+function scoreTeam(team){
+  let score = 0;
+  for(const opponent of top25){
+    if(team.includes(opponent)) continue;
+    for(const member of team){
+      for(const shields of shieldScenarios){
+        const rating = simulate(member, opponent, shields[0], shields[1]);
+        if(rating > 500){
+          score++;
+        }
+      }
+    }
+  }
+  return score;
+}
+
+const limitArg = process.argv.find(a => a.startsWith('--limit='));
+const limit = limitArg ? parseInt(limitArg.split('=')[1]) : Infinity;
+
+let bestTeam = null;
+let bestScore = -1;
+let count = 0;
+
+for(const combo of combinations(top25, 3)){
+  const s = scoreTeam(combo);
+  if(s > bestScore){
+    bestScore = s;
+    bestTeam = combo;
+  }
+  count++;
+  if(count >= limit) break;
+}
+
+console.log('Evaluated', count, 'team combinations');
+if(bestTeam){
+  console.log('Best team:', bestTeam.join(', '), 'score', bestScore);
+}


### PR DESCRIPTION
## Summary
- add Node script to evaluate every 3-Pokémon combination from the top 25 Great League meta across 0-0, 1-1, and 2-2 shield scenarios
- document how to run the new script locally

## Testing
- `node src/scripts/top25triplets.js --limit=1`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bacb20a5488329ab9718f0448f1714