### PR TITLE
feat: allow variable team size for meta evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See the [Installation](https://github.com/pvpoke/pvpoke/wiki/Installation) secti
 
 ## Top 25 Team Combinations (Great League)
 
-The `src/scripts/top25triplets.js` script exhaustively evaluates every team of three from the top 25 Great League meta. Each trio is tested against the meta across the 0-0, 1-1, and 2-2 shield scenarios to find the highest-scoring combination.
+The `src/scripts/top25triplets.js` script exhaustively evaluates every team from the top 25 Great League meta. By default, it evaluates teams of three, but you can specify teams of six (or other sizes) with the `--team-size` option. Each team is tested against the meta across the 0-0, 1-1, and 2-2 shield scenarios to find the highest-scoring combination.
 
 
 Run the script locally with:
@@ -21,7 +21,13 @@ Run the script locally with:
 npm run triplets:top25
 ```
 
-Processing all 2300 combinations may take significant time. For a quicker trial run, append `--limit=<number>` to evaluate only the first N combinations.
+To evaluate larger teams, append the `--team-size` flag:
+
+```bash
+npm run triplets:top25 -- --team-size=6
+```
+
+Processing all combinations may take significant time. For a quicker trial run, append `--limit=<number>` to evaluate only the first N combinations.
 
 
 ## Site Structure

--- a/src/scripts/top25triplets.js
+++ b/src/scripts/top25triplets.js
@@ -83,6 +83,9 @@ const metaArg = process.argv.find(a => a.startsWith('--meta='));
 const metaCount = metaArg ? parseInt(metaArg.split('=')[1]) : 25;
 const meta = rankings.slice(0, metaCount).map(p => p.speciesId);
 
+const teamSizeArg = process.argv.find(a => a.startsWith('--team-size='));
+const teamSize = teamSizeArg ? parseInt(teamSizeArg.split('=')[1]) : 3;
+
 
 const shieldScenarios = [ [0,0], [1,1], [2,2] ];
 
@@ -121,7 +124,7 @@ const limit = limitArg ? parseInt(limitArg.split('=')[1]) : Infinity;
 const topTeams = [];
 let count = 0;
 
-for(const combo of combinations(meta, 3)){
+for(const combo of combinations(meta, teamSize)){
   const s = scoreTeam(combo);
   topTeams.push({ team: combo, score: s });
   topTeams.sort((a, b) => b.score - a.score);
@@ -131,7 +134,7 @@ for(const combo of combinations(meta, 3)){
   if(count >= limit) break;
 }
 
-console.log('Evaluated', count, 'team combinations');
+console.log('Evaluated', count, `team combinations of size ${teamSize}`);
 
 topTeams.forEach((entry, i) => {
   console.log(`#${i+1}: ${entry.team.join(', ')} score ${entry.score}`);


### PR DESCRIPTION
## Summary
- allow specifying team size when evaluating top-25 meta teams
- document new team-size option in README

## Testing
- `npm run triplets:top25 -- --limit=1`
- `npm run triplets:top25 -- --limit=1 --team-size=6`


------
https://chatgpt.com/codex/tasks/task_e_68bb2f5a33b483298d8cee28dbd7f88e